### PR TITLE
Update challenge.scss 修复编程挑战时候代码框显示问题（代码框只有一窄条）

### DIFF
--- a/src/assets/styles/view-style/challenge.scss
+++ b/src/assets/styles/view-style/challenge.scss
@@ -74,7 +74,7 @@
     }
     .content{
         width: calc(100vw - 150px - 130px);
-        height: calc(100vh - 140px - 87px - 7px);
+        height: calc(100vh - 50px);
         margin: 0 130px 0 150px;
         padding-bottom: 50px;
         // box-sizing: content-box;


### PR DESCRIPTION
这个 height 太小，导致编程页面的代码
框只有几个像素的高度，基本无法使用

### 修改前：
<img width="1344" alt="代码编辑器BUG" src="https://github.com/user-attachments/assets/a0f4ea31-0925-490a-9c08-43f03a2880ab" />
### 修改后：
<img width="1344" alt="代码编辑器BUG修复" src="https://github.com/user-attachments/assets/7a05b1ea-fed0-41fc-8e30-61879fc378ce" />
